### PR TITLE
Add an option to subscribe to compressed image topics.

### DIFF
--- a/aruco_opencv/config/aruco_tracker.yaml
+++ b/aruco_opencv/config/aruco_tracker.yaml
@@ -5,6 +5,7 @@
 
     marker_dict: 4X4_50
 
+    image_sub_compressed: false
     image_sub_qos:
       reliability: 2 # 0 - system default, 1 - reliable, 2 - best effort
       durability: 2 # 0 - system default, 1 - transient local, 2 - volatile

--- a/aruco_opencv/package.xml
+++ b/aruco_opencv/package.xml
@@ -36,7 +36,6 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>yaml-cpp</exec_depend>
-  <exec_depend>compressed_image_transport</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/aruco_opencv/package.xml
+++ b/aruco_opencv/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>yaml-cpp</exec_depend>
+  <exec_depend>compressed_image_transport</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -161,7 +161,9 @@ public:
     cam_info_retrieved_ = false;
 
     std::string cam_info_topic = image_transport::getCameraInfoTopic(cam_base_topic_);
-    if (cam_base_topic_.size() > 0 && cam_base_topic_[0] != '/' && cam_info_topic.size() > 0 && cam_info_topic[0] == '/') {
+    if (cam_base_topic_.size() > 0 && cam_base_topic_[0] != '/' &&
+      cam_info_topic.size() > 0 && cam_info_topic[0] == '/')
+    {
       // Remove leading slash to allow for relative camera_base_topic.
       cam_info_topic = cam_info_topic.substr(1);
     }

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -178,11 +178,11 @@ public:
 
     if (image_sub_compressed_) {
       compressed_img_sub_ = create_subscription<sensor_msgs::msg::CompressedImage>(
-        cam_base_topic_ + "/compressed", qos, std::bind(
+        image_topic + "/compressed", qos, std::bind(
           &ArucoTracker::callback_compressed_image, this, std::placeholders::_1));
     } else {
       img_sub_ = create_subscription<sensor_msgs::msg::Image>(
-        cam_base_topic_, qos, std::bind(
+        image_topic, qos, std::bind(
           &ArucoTracker::callback_image, this, std::placeholders::_1));
     }
 

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -576,7 +576,7 @@ protected:
       auto debug_cv_ptr = std::make_shared<cv_bridge::CvImage>();
       debug_cv_ptr->header = cv_ptr->header;
       debug_cv_ptr->encoding = cv_ptr->encoding;
-      debug_cv_ptr->image = cv_ptr->image.clone();  // copy elision
+      debug_cv_ptr->image = cv_ptr->image.clone();
       cv::aruco::drawDetectedMarkers(debug_cv_ptr->image, marker_corners, marker_ids);
       {
         std::lock_guard<std::mutex> guard(cam_info_mutex_);

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -431,7 +431,9 @@ protected:
   {
     // Decompress the image using bridge
     auto image = cv_bridge::toCvCopy(img_msg, "bgr8");
-    callback_image(image->toImageMsg());
+    auto new_msg = image->toImageMsg();
+    new_msg->header = img_msg->header;
+    callback_image(new_msg);
   }
 
   void callback_image(const sensor_msgs::msg::Image::ConstSharedPtr img_msg)

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -160,13 +160,9 @@ public:
 
     cam_info_retrieved_ = false;
 
-    std::string cam_info_topic = image_transport::getCameraInfoTopic(cam_base_topic_);
-    if (cam_base_topic_.size() > 0 && cam_base_topic_[0] != '/' &&
-      cam_info_topic.size() > 0 && cam_info_topic[0] == '/')
-    {
-      // Remove leading slash to allow for relative camera_base_topic.
-      cam_info_topic = cam_info_topic.substr(1);
-    }
+    std::string image_topic = rclcpp::expand_topic_or_service_name(
+      cam_base_topic_, this->get_name(), this->get_namespace());
+    std::string cam_info_topic = image_transport::getCameraInfoTopic(image_topic);
 
     cam_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>(
       cam_info_topic, 1,

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -227,6 +227,7 @@ public:
     on_set_parameter_callback_handle_.reset();
     cam_info_sub_.reset();
     img_sub_.reset();
+    compressed_img_sub_.reset();
     tf_listener_.reset();
     tf_buffer_.reset();
     tf_broadcaster_.reset();


### PR DESCRIPTION
- Also allow for relative names in cam_base_topic.

I have added a new parameter called `image_sub_compressed: false`. When enabled, aruco_tracker will subscribe to `cam_base_topic/compressed` instead of `cam_base_topic`.

This modification is a workaround, because normally, image compression is handled by setting `image_transport::TransportHints`. However we are unable to use image_transport with lifecycle nodes. 

Enabling this feature makes aruco_tracker work much faster and allows us to successfully use it with a multi-camera setup.
