### PR TITLE
Fix out of bounds indexes when retrieving camera matrix for rectified images

### DIFF
--- a/aruco_opencv/config/aruco_tracker.yaml
+++ b/aruco_opencv/config/aruco_tracker.yaml
@@ -5,6 +5,7 @@
 
     marker_dict: 4X4_50
 
+    image_is_rectified: false
     image_sub_compressed: false
     image_sub_qos:
       reliability: 2 # 0 - system default, 1 - reliable, 2 - best effort

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -408,8 +408,8 @@ protected:
     std::lock_guard<std::mutex> guard(cam_info_mutex_);
 
     if (image_is_rectified_) {
-      for (int i = 0; i < 12; ++i) {
-        camera_matrix_.at<double>(i / 4, i % 4) = cam_info->p[i];
+      for (int i = 0; i < 9; ++i) {
+        camera_matrix_.at<double>(i / 3, i % 3) = cam_info->p[i + i / 3];
       }
     } else {
       for (int i = 0; i < 9; ++i) {


### PR DESCRIPTION
After merging #46 I noticed that the ROS2 port tries to fit 3x4 Projection matrix into 3x3 cv::Mat which results in out of bounds indexes. This did not raise an exception as OpenCv does array range checking only in Debug mode.

This PR makes the camera matrix retrieval for rectified images work the same as in ROS1 version after applying fix from @real-Sandip-Das

I also added `image_is_rectified` parameter, which was missing for a long time, to the example yaml file.