### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/aruco_opencv/CMakeLists.txt
+++ b/aruco_opencv/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(${PROJECT_NAME} SHARED
   src/aruco_tracker.cpp
   src/utils.cpp
 )
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   rclcpp_components::component
@@ -26,10 +26,8 @@ target_link_libraries(${PROJECT_NAME}
   image_transport::image_transport
   opencv_aruco
   ${YAML_CPP_LIBRARIES}
-)
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  aruco_opencv_msgs
-  cv_bridge
+  ${aruco_opencv_msgs_TARGETS}
+  cv_bridge::cv_bridge
 )
 target_include_directories(${PROJECT_NAME}
   PRIVATE

--- a/aruco_opencv/CMakeLists.txt
+++ b/aruco_opencv/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(${PROJECT_NAME}
   opencv_aruco
   ${YAML_CPP_LIBRARIES}
 )
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   aruco_opencv_msgs
   cv_bridge
 )


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
