### PR TITLE
Add support for camera with bgra8 encoding

### DIFF
--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -332,11 +332,9 @@ protected:
     }
 
     cv_bridge::CvImageConstPtr cv_ptr;
-    if(img_msg->encoding == "bgra8"){
-      cv_ptr = cv_bridge::toCvShare(img_msg, "bgr8");
-      RCLCPP_INFO_ONCE(this->get_logger(), "image has been converted to bgr8");
-    }
-    else{
+    if (sensor_msgs::image_encodings::hasAlpha(img_msg->encoding)) {
+      cv_ptr = cv_bridge::toCvCopy(img_msg, "bgr8");
+    } else {
       cv_ptr = cv_bridge::toCvShare(img_msg);
     }
     process_image(cv_ptr);

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -36,6 +36,7 @@
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/image_encodings.hpp"
 #include "image_transport/camera_common.hpp"
 
 #include "aruco_opencv_msgs/msg/aruco_detection.hpp"

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -333,8 +333,8 @@ protected:
 
     cv_bridge::CvImageConstPtr cv_ptr;
     if(img_msg->encoding == "bgra8"){
+      cv_ptr = cv_bridge::toCvShare(img_msg, "bgr8");
       RCLCPP_INFO_ONCE(this->get_logger(), "image has been converted to bgr8");
-      cv_ptr = cv_bridge::toCvShare(img_msg, "bgr8"); 
     }
     else{
       cv_ptr = cv_bridge::toCvShare(img_msg);

--- a/aruco_opencv/src/aruco_tracker.cpp
+++ b/aruco_opencv/src/aruco_tracker.cpp
@@ -331,7 +331,14 @@ protected:
       return;
     }
 
-    auto cv_ptr = cv_bridge::toCvShare(img_msg);
+    cv_bridge::CvImageConstPtr cv_ptr;
+    if(img_msg->encoding == "bgra8"){
+      RCLCPP_INFO_ONCE(this->get_logger(), "image has been converted to bgr8");
+      cv_ptr = cv_bridge::toCvShare(img_msg, "bgr8"); 
+    }
+    else{
+      cv_ptr = cv_bridge::toCvShare(img_msg);
+    }
     process_image(cv_ptr);
   }
 


### PR DESCRIPTION
This PR introduces a support for cameras that publish images in bgra8 format, such as ZED cameras.
Current implementation converts incoming ros2 image messages using cv_bridge::toCvShare(img_msg) without taking the encoding into account. While this is okay for e.g. 3-channel images, it also allows bgra8 to pass unchanged. The issue is that detector strictly expects a 1-channel or 3-channel image, resulting in OpenCV throwing an exception: 
```
terminate called after throwing an instance of 'cv::Exception'
 what():  OpenCV(4.5.4) ./contrib/modules/aruco/src/aruco.cpp:107: error: (-215:Assertion failed) _in.type() == CV_8UC1 || _in.type() == CV_8UC3 in function '_convertToGrey'
```
PR modifies the callback_image function to check the incoming image encoding. If the encoding is bgra8, it now performs a conversion to bgr8 using cv_bridge::toCvShare(img_msg, "bgr8") and print a log message to inform the user.